### PR TITLE
Fix encoding issue on Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ allprojects {
 	defaultTasks "build"
 }
 
+// Workaround to build proper jars on Windows, see https://github.com/Frege/frege-gradle-plugin/issues/9
+System.setProperty("file.encoding", "UTF-8")
 
 buildscript {        // make the frege plugin available in our build
     repositories {


### PR DESCRIPTION
That is a workaround for https://github.com/Frege/frege-gradle-plugin/issues/9. We may remove it if the issue will be resolved in the plugin itself.
